### PR TITLE
Fix duplicate function name.

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,6 @@ def page_not_found(e):
 
 
 @app.errorhandler(500)
-def page_not_found(e):
+def on_app_error(e):
     """Return a custom 500 error."""
     return 'Sorry, unexpected error: {}'.format(e), 500


### PR DESCRIPTION
"page_not_found" was used for both the 404 and 500 errorhandlers. Fixed by giving the 500 error handler its own name.